### PR TITLE
Add return value to WaitForCacheSync

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ factory := xnsinformers.NewSharedInformerFactoryWithOptions(
 // Create an informer for ConfigMap resources.
 resource := corev1.SchemeGroupVersion.WithResource("configmaps")
 informer := factory.NamespacedResource(resource)
+informer := factory.ForResource(resource, xnsinformers.ResourceOptions{
+    ClusterScoped: false,
+})
 
 // Add an event handler to the new informer.
 informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/informers/factory.go
+++ b/pkg/informers/factory.go
@@ -23,7 +23,7 @@ import (
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
 	ForResource(gvr schema.GroupVersionResource, opts ResourceOptions) informers.GenericInformer
-	WaitForCacheSync(stopCh <-chan struct{})
+	WaitForCacheSync(stopCh <-chan struct{}) bool
 	SetNamespaces(namespaces []string)
 	GetScheme() *runtime.Scheme
 }
@@ -252,7 +252,7 @@ func (f *multiNamespaceInformerFactory) Start(stopCh <-chan struct{}) {
 }
 
 // WaitForCacheSync waits for all previously started informers caches to sync.
-func (f *multiNamespaceInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) {
+func (f *multiNamespaceInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) bool {
 	syncFuncs := func() (syncFuncs []cache.InformerSynced) {
 		f.lock.Lock()
 		defer f.lock.Unlock()
@@ -264,5 +264,5 @@ func (f *multiNamespaceInformerFactory) WaitForCacheSync(stopCh <-chan struct{})
 		return
 	}
 
-	cache.WaitForCacheSync(stopCh, syncFuncs()...)
+	return cache.WaitForCacheSync(stopCh, syncFuncs()...)
 }


### PR DESCRIPTION
This adds a boolean return value to `WaitForCacheSync` so we can make the `fastWaitForCacheSync` bit used for Istio tests happy.

Ideally this would return a `map[schema.GroupVersionResource]bool` indicating the status for each resource type, but the recent change to cache informers for both unstructured and structured types makes that awkward. I have a feeling we should instead just have separate structured and unstructured factories with a shared common base, but this is a quick fix.