### PR TITLE
Update istio.io/client-go to v1.9.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/tools v0.0.0-20200930213115-e57f6d466a48 // indirect
 	google.golang.org/appengine v1.6.6 // indirect
-	istio.io/client-go v1.9.4
+	istio.io/client-go v0.0.0-20210503213042-e6eb157f0d81
 	k8s.io/api v0.20.1
 	k8s.io/apimachinery v0.20.1
 	k8s.io/client-go v0.20.1

--- a/go.sum
+++ b/go.sum
@@ -730,10 +730,10 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-istio.io/api v0.0.0-20210420211535-1c598ea4139c h1:SDcswV02XpOBtlWt3vhC+N3JvKS3qXZdL4zj83kHiwk=
-istio.io/api v0.0.0-20210420211535-1c598ea4139c/go.mod h1:88HN3o1fSD1jo+Z1WTLlJfMm9biopur6Ct9BFKjiB64=
-istio.io/client-go v1.9.4 h1:rqn+GtI0XO8d8haR315hNuKMdq8lD/NPj5SH0nNfFiw=
-istio.io/client-go v1.9.4/go.mod h1:LZ8ZCa52HrZIiNbVbK0wC0Xf+Bc5dXbIwyk5izXe/9M=
+istio.io/api v0.0.0-20210503211644-902e709f95c4 h1:K3ocz4u1m9Vnz0gTkcxwFIFTpiuecMXOJY/K40ZMRws=
+istio.io/api v0.0.0-20210503211644-902e709f95c4/go.mod h1:88HN3o1fSD1jo+Z1WTLlJfMm9biopur6Ct9BFKjiB64=
+istio.io/client-go v0.0.0-20210503213042-e6eb157f0d81 h1:AROGKN55WdNHEJ6ujyZlvbM9S8jr/uDmDYWxsSVUuSg=
+istio.io/client-go v0.0.0-20210503213042-e6eb157f0d81/go.mod h1:LAkylvGs/+IEUnUXfYqMS5y0lLx45ruBTds327AdmIQ=
 istio.io/gogo-genproto v0.0.0-20190930162913-45029607206a h1:w7zILua2dnYo9CxImhpNW4NE/8ZxEoc/wfBfHrhUhrE=
 istio.io/gogo-genproto v0.0.0-20190930162913-45029607206a/go.mod h1:OzpAts7jljZceG4Vqi5/zXy/pOg1b209T3jb7Nv5wIs=
 k8s.io/api v0.18.2/go.mod h1:SJCWI7OLzhZSvbY7U8zwNl9UA4o1fizoug34OV/2r78=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -129,14 +129,14 @@ google.golang.org/protobuf/types/known/timestamppb
 gopkg.in/inf.v0
 # gopkg.in/yaml.v2 v2.3.0
 gopkg.in/yaml.v2
-# istio.io/api v0.0.0-20210420211535-1c598ea4139c
+# istio.io/api v0.0.0-20210503211644-902e709f95c4
 istio.io/api/analysis/v1alpha1
 istio.io/api/meta/v1alpha1
 istio.io/api/networking/v1alpha3
 istio.io/api/networking/v1beta1
 istio.io/api/security/v1beta1
 istio.io/api/type/v1beta1
-# istio.io/client-go v1.9.4
+# istio.io/client-go v0.0.0-20210503213042-e6eb157f0d81
 ## explicit
 istio.io/client-go/pkg/apis/networking/v1alpha3
 istio.io/client-go/pkg/apis/networking/v1beta1


### PR DESCRIPTION
Because client-go is tagged as 1.9.5 instead of v1.9.5, we need to import it as v0.0.0-20210503213042-e6eb157f0d81.