### PR TITLE
OSSM-2203: removes replace for controller-gen

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,9 @@ module github.com/maistra/xns-informer
 
 go 1.19
 
-replace sigs.k8s.io/controller-runtime v0.10.3 => sigs.k8s.io/controller-runtime v0.11.2
-
 require (
 	github.com/spf13/pflag v1.0.5
-	istio.io/client-go v1.16.0-beta.1.0.20221026014218-7c812364cece
+	istio.io/client-go v1.16.0-beta.2.0.20221102013820-4276379da487
 	k8s.io/api v0.25.1
 	k8s.io/apimachinery v0.25.1
 	k8s.io/client-go v0.25.1
@@ -66,7 +64,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	istio.io/api v0.0.0-20221026013620-ffb8a5483c63 // indirect
+	istio.io/api v0.0.0-20221102013421-7906f6f2bcb5 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803164354-a70c9af30aea // indirect
 	k8s.io/utils v0.0.0-20220823124924-e9cbc92d1a73 // indirect
 	sigs.k8s.io/controller-runtime v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -783,10 +783,10 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-istio.io/api v0.0.0-20221026013620-ffb8a5483c63 h1:2LXTUMO9gtMARDfDnMM0ifan2H+YWj1qGQOxlQcamBY=
-istio.io/api v0.0.0-20221026013620-ffb8a5483c63/go.mod h1:hQkF0Q19MCmfOTre/Sg4KvrwwETq45oaFplnBm2p4j8=
-istio.io/client-go v1.16.0-beta.1.0.20221026014218-7c812364cece h1:n1WRiNw/7kvpHnU2HMnDW2bowpeBcdybT9cJLxd/Z8g=
-istio.io/client-go v1.16.0-beta.1.0.20221026014218-7c812364cece/go.mod h1:9nGZCTT0oEHLdV1KOi+nem0XOToFUqmkhqaYidHs1is=
+istio.io/api v0.0.0-20221102013421-7906f6f2bcb5 h1:8kzD0/xK6UHbq+pteNPHq8L/SuE4LIzZ9VBpX2Y7lgw=
+istio.io/api v0.0.0-20221102013421-7906f6f2bcb5/go.mod h1:hQkF0Q19MCmfOTre/Sg4KvrwwETq45oaFplnBm2p4j8=
+istio.io/client-go v1.16.0-beta.2.0.20221102013820-4276379da487 h1:hcbuEtqOdNSuwkSXTkck5b64ukd3UFOlQUbuNxbddVE=
+istio.io/client-go v1.16.0-beta.2.0.20221102013820-4276379da487/go.mod h1:4y/b4mVraxY9Bl+X6+43jJCC9JEHhu9CRZO0Htxd0QU=
 k8s.io/api v0.25.1 h1:yL7du50yc93k17nH/Xe9jujAYrcDkI/i5DL1jPz4E3M=
 k8s.io/api v0.25.1/go.mod h1:hh4itDvrWSJsmeUc28rIFNri8MatNAAxJjKcQmhX6TU=
 k8s.io/apiextensions-apiserver v0.25.0 h1:CJ9zlyXAbq0FIW8CD7HHyozCMBpDSiH7EdrSTCZcZFY=


### PR DESCRIPTION
This rule doesn't seem too relevant anymore.

Also istio-{api,client} version has been bumped in upstream so I sneaked it in.